### PR TITLE
Add default nightly case start

### DIFF
--- a/scripts/nightly_chancery_start.sql
+++ b/scripts/nightly_chancery_start.sql
@@ -18,10 +18,13 @@ WITH serials AS (
         AND substr(case_number, 1, 4) = strftime('%Y', current_timestamp)
 )
 
-SELECT serial
-FROM
-    serials
-ORDER BY
-    -serial
-LIMIT
-    1;
+-- If we don't have any cases for the current year, start from zero
+SELECT coalesce((
+    SELECT serial
+    FROM
+        serials
+    ORDER BY
+        -serial
+    LIMIT
+        1
+), 0);

--- a/scripts/nightly_civil_start.sql
+++ b/scripts/nightly_civil_start.sql
@@ -18,10 +18,13 @@ WITH serials AS (
         AND substr(case_number, 1, 4) = strftime('%Y', current_timestamp)
 )
 
-SELECT serial
-FROM
-    serials
-ORDER BY
-    -serial
-LIMIT
-    1;
+-- If we don't have any cases for the current year, start from zero
+SELECT coalesce((
+    SELECT serial
+    FROM
+        serials
+    ORDER BY
+        -serial
+    LIMIT
+        1
+), 0);


### PR DESCRIPTION
## Overview

We didn't set a default starting case serial number (i.e. 0) when the DB doesn't yet have any cases in the current year.

## Testing Instructions

- Verify that `make get_new_records` starts scrapes without error