### PR TITLE
Add court call scrape

### DIFF
--- a/.github/workflows/court_calls.yml
+++ b/.github/workflows/court_calls.yml
@@ -1,13 +1,13 @@
-name: Nightly case scrape
+name: Court call scrape
 
 on:
   workflow_dispatch:
   schedule:
-     - cron: '15 4 * * *'
+     - cron: '15 10 * * *'
 
 jobs:
   scrape:
-    name: Scrape new cases
+    name: Scrape court calls
     runs-on: ubuntu-latest
 
     steps:
@@ -35,10 +35,9 @@ jobs:
         run: |
           unzip -P '${{ secrets.CASE_DB_PW }}' cases.db.zip && rm cases.db.zip
 
-      - name: Run case scrape
+      - name: Scrape court calls
         run: |
-          echo $BEGIN_COURTS_RUN
-          make get_new_records
+          make -f Makefile.courtcalls all
 
       - name: Setup database for upload
         run: |
@@ -112,5 +111,6 @@ jobs:
           datasette publish heroku cases.db \
               -n court-scraper \
               -m metadata.json \
+              --setting sql_time_limit_ms 60000 \
               --install datasette-auth-passwords \
               --plugin-secret datasette-auth-passwords root_password_hash '${{ env.hash }}'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,6 +41,7 @@ jobs:
           make get_new_records
 
       - name: Scrape court calls
+        run: |
           make -f Makefile.courtcalls all
 
       - name: Setup database for upload

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,10 +35,13 @@ jobs:
         run: |
           unzip -P '${{ secrets.CASE_DB_PW }}' cases.db.zip && rm cases.db.zip
 
-      - name: Run scrape
+      - name: Run case scrape
         run: |
           echo $BEGIN_COURTS_RUN
           make get_new_records
+
+      - name: Scrape court calls
+          make -f Makefile.courtcalls all
 
       - name: Setup database for upload
         run: |

--- a/Makefile.courtcalls
+++ b/Makefile.courtcalls
@@ -1,0 +1,14 @@
+# Makefile for scraping court calls
+
+.PHONY : all
+all: court_calls.csv cases.db
+	cat $< | sqlite3 cases.db -init scripts/import_court_calls.sql -bail
+
+court_calls.csv: court_calls.json
+	cat $^ | jq '.[] | [.["Case Number"], .["Division"], .["Plaintiff"], .["Defendant"], .["Court Date"], .["Room"], .["District"], .["Sequence #"], .["Time"], .hash] | @csv' -r > $@
+
+court_calls.json: court_calls.jl
+	cat $^ | jq --slurp '.' > $@
+
+court_calls.jl : cases.db
+	scrapy crawl courtcalls -s CLOSESPIDER_TIMEOUT=14400 -O $@

--- a/courtscraper/spiders/court_calls.py
+++ b/courtscraper/spiders/court_calls.py
@@ -179,13 +179,13 @@ class CourtCallSpider(ABC, Spider):
         return form_data
 
     def parse_results(self, response):
-        cases = self.get_court_calls(response)
-        if not cases:
+        results = self.get_court_calls(response)
+        if not results:
             return
 
-        for case in cases:
-            case["hash"] = dict_hash(case)
-            yield case
+        for court_call in results:
+            court_call["hash"] = dict_hash(court_call)
+            yield court_call
 
         # Request the next page of results
         next_page_num = response.meta["result_page_num"] + 1

--- a/courtscraper/spiders/court_calls.py
+++ b/courtscraper/spiders/court_calls.py
@@ -1,4 +1,3 @@
-from abc import ABC
 from datetime import datetime, timedelta
 
 from scrapy import Spider, Request
@@ -11,7 +10,7 @@ from lxml import html
 from scripts.hash import dict_hash
 
 
-class CourtCallSpider(ABC, Spider):
+class CourtCallSpider(Spider):
     name = "courtcalls"
     url = "https://casesearch.cookcountyclerkofcourt.org/CourtCallSearch.aspx"
 
@@ -19,7 +18,7 @@ class CourtCallSpider(ABC, Spider):
         self.failures = set()
         super().__init__(**kwargs)
 
-    def nextBusinessDays(self, n):
+    def next_business_days(self, n):
         """Returns the dates of the next n business days."""
 
         current_date = datetime.today()
@@ -36,7 +35,7 @@ class CourtCallSpider(ABC, Spider):
             count += 1
 
     def start_requests(self):
-        for date in self.nextBusinessDays(5):
+        for date in self.next_business_days(5):
             yield Request(
                 CourtCallSpider.url,
                 meta={

--- a/courtscraper/spiders/court_calls.py
+++ b/courtscraper/spiders/court_calls.py
@@ -1,0 +1,174 @@
+from abc import ABC
+
+from scrapy import Spider, Request
+from scrapy.http import FormRequest
+from scrapy.spidermiddlewares.httperror import HttpError
+
+from lxml import html
+
+from scripts.hash import dict_hash
+
+
+class CourtCallSpider(ABC, Spider):
+    name = "courtcalls"
+    url = "https://casesearch.cookcountyclerkofcourt.org/CourtCallSearch.aspx"
+
+    def __init__(self, **kwargs):
+        self.current_page = 1
+        super().__init__(**kwargs)
+
+    def nextBusinessDays(self, n):
+        """Returns the dates of the next n business days."""
+
+        return ["3/12/2024"]
+
+    def start_requests(self):
+        for date in self.nextBusinessDays(5):
+            self.current_page = 1
+            yield Request(
+                CourtCallSpider.url,
+                meta={
+                    "zyte_api_automap": {
+                        "httpResponseHeaders": True,
+                        "browserHtml": True,
+                        "actions": [
+                            {
+                                "action": "waitForSelector",
+                                "selector": {
+                                    "type": "css",
+                                    "value": "#MainContent_rblSearchType_2",
+                                },
+                                "timeout": 5,
+                                "onError": "return",
+                            },
+                            {
+                                "action": "click",
+                                "selector": {
+                                    "type": "css",
+                                    "value": "#MainContent_rblSearchType_2",
+                                },
+                                "onError": "return",
+                            },
+                            {
+                                "action": "waitForSelector",
+                                "selector": {
+                                    "type": "css",
+                                    "value": "#MainContent_dtTxt",
+                                },
+                                "timeout": 5,
+                                "onError": "return",
+                            },
+                            {
+                                "action": "select",
+                                "selector": {
+                                    "type": "css",
+                                    "value": "#MainContent_ddlDivisionCode",
+                                },
+                                "values": ["CV"],
+                                "onError": "return",
+                            },
+                            {
+                                "action": "type",
+                                "selector": {
+                                    "type": "css",
+                                    "value": "#MainContent_dtTxt",
+                                },
+                                "text": date,
+                                "onError": "return",
+                            },
+                            {
+                                "action": "click",
+                                "selector": {
+                                    "type": "css",
+                                    "value": "#MainContent_btnSearch",
+                                },
+                                "onError": "return",
+                            },
+                            {
+                                "action": "waitForSelector",
+                                "selector": {
+                                    "type": "css",
+                                    "value": "#MainContent_pnlResults",
+                                },
+                                "timeout": 5,
+                                "onError": "return",
+                            },
+                        ],
+                    },
+                    "date": date,
+                },
+                errback=self.handle_error,
+            )
+
+    def has_page_num(self, n, response):
+        """Check if there's another page of court calls."""
+        tree = html.fromstring(response.text)
+        page_table = tree.xpath("//table")[1]
+        next_page_link = page_table.xpath(f".//a[contains(@href,'Page${n}')]")
+        return bool(next_page_link)
+
+    def get_court_calls(self, response):
+        tree = html.fromstring(response.text)
+        results_table = tree.xpath("//table[@id='MainContent_grdRecords']")[0]
+
+        rows = results_table.xpath(".//tr")
+        headers = rows[0].xpath(".//a/text()")
+        for row in rows[1:-1]:
+            cells = row.xpath(".//td/text()")
+            if cells:
+                yield dict(zip(headers, cells))
+
+    def extract_form(self, response, form_xpath):
+        form_data = dict()
+
+        for hidden_input in response.xpath(form_xpath).xpath(
+            ".//input[@type='hidden']"
+        ):
+            name = hidden_input.attrib.get("name")
+            if name is None:
+                continue
+            value = hidden_input.attrib.get("value")
+            if value is None:
+                value = ""
+
+            form_data[name] = value
+
+        return form_data
+
+    def get_page_n_form_data(self, n, response):
+        form_data = self.extract_form(response, "//form[@id='ctl01']")
+        form_data["__EVENTTARGET"] = "ctl00$MainContent$grdRecords"
+        form_data["__EVENTARGUMENT"] = f"Page${n}"
+        return form_data
+
+    def parse(self, response):
+        cases = self.get_court_calls(response)
+        for case in cases:
+            case["hash"] = dict_hash(case)
+            yield case
+
+        breakpoint()
+        self.current_page += 1
+        next_page = self.has_page_num(self.current_page, response)
+        if not next_page:
+            return
+
+        # self._success(response)
+        next_page_form_data = self.get_page_n_form_data(self.current_page, response)
+        yield FormRequest.from_response(
+            response,
+            formxpath="//form[@id='ctl01']",
+            formdata=next_page_form_data,
+            callback=self.parse,
+            dont_click=True,
+        )
+
+    def handle_error(self, failure):
+        if failure.check(HttpError):
+            response = failure.value.response
+            if response.status == 404:
+                self._missing_case(response)
+            elif response.status == 500:
+                self._failing_responses(response)
+        else:
+            self.logger.error(repr(failure))

--- a/courtscraper/spiders/court_calls.py
+++ b/courtscraper/spiders/court_calls.py
@@ -1,4 +1,5 @@
 from abc import ABC
+from datetime import datetime, timedelta
 
 from scrapy import Spider, Request
 from scrapy.http import FormRequest
@@ -20,7 +21,18 @@ class CourtCallSpider(ABC, Spider):
     def nextBusinessDays(self, n):
         """Returns the dates of the next n business days."""
 
-        return ["3/12/2024"]
+        current_date = datetime.today()
+        count = 0
+        while count <= n:
+            yield f"{current_date.month}/{current_date.day}/{current_date.year}"
+
+            next_date = current_date + timedelta(days=1)
+            while next_date.weekday() > 4:
+                # Skip weekends
+                next_date += timedelta(days=1)
+
+            current_date = next_date
+            count += 1
 
     def start_requests(self):
         for date in self.nextBusinessDays(5):
@@ -147,7 +159,6 @@ class CourtCallSpider(ABC, Spider):
             case["hash"] = dict_hash(case)
             yield case
 
-        breakpoint()
         self.current_page += 1
         next_page = self.has_page_num(self.current_page, response)
         if not next_page:

--- a/scripts/import_court_calls.sql
+++ b/scripts/import_court_calls.sql
@@ -1,0 +1,46 @@
+CREATE TEMPORARY TABLE raw_court_call (
+    case_number text,
+    division text,
+    plaintiff text,
+    defendant text,
+    court_date text,
+    room text,
+    district text,
+    sequence text,
+    time text,
+    hash text
+);
+
+-- noqa: disable=PRS
+.mode csv
+.import /dev/stdin raw_court_call
+-- noqa: enable=PRS
+
+-- Find and insert the new court calls
+INSERT INTO
+  court_call(
+    case_number,
+    division,
+    plaintiff,
+    defendant,
+    court_date,
+    room,
+    district,
+    sequence,
+    time,
+    hash
+  )
+SELECT
+  case_number,
+  division,
+  plaintiff,
+  defendant,
+  court_date,
+  room,
+  district,
+  sequence,
+  time,
+  hash
+FROM
+  raw_court_call
+WHERE raw_court_call.hash NOT IN (SELECT hash FROM court_call);

--- a/scripts/initialize_db.sql
+++ b/scripts/initialize_db.sql
@@ -39,3 +39,17 @@ CREATE TABLE event(
   comments text,
   FOREIGN KEY(case_number) REFERENCES court_case(case_number)
 );
+
+CREATE TABLE court_call(
+	case_number text not null,
+	division,
+	plaintiff,
+	defendant,
+	court_date,
+	room,
+	district,
+	sequence,
+	time,
+	hash,
+  FOREIGN KEY(case_number) REFERENCES court_case(case_number)
+);


### PR DESCRIPTION
## Overview

This PR adds court call scraping to the nightly scrape action.

## Notes

### Preventing duplicate court call rows

Court calls are updated nightly so we'll be scraping a single court call multiple times over the course of a few days. I added a `hash` column to the `court_call` table to ensure that we don't have duplicates.

### Not-yet scraped court cases

Court calls scrapes include cases that might not be in the database yet. The `court_call` table still have a foreign key to the `court_case` table but not all of the rows in `court_call` will map to a valid court case.