### PR TITLE
Add column constraints 

### DIFF
--- a/scripts/initialize_db.sql
+++ b/scripts/initialize_db.sql
@@ -1,40 +1,40 @@
 -- noqa: disable=PRS
 CREATE TABLE court_case(
   case_number not null primary key,
-  filing_date text,
-  division text,
+  filing_date text not null,
+  division text not null,
   subdivision text,
-  case_type text,
-  calendar text,
-  ad_damnum text,
-  court text,
-  hash text,
+  case_type text not null,
+  calendar text not null,
+  ad_damnum text not null,
+  court text not null,
+  hash text not null,
   scraped_at text default CURRENT_TIMESTAMP,
   updated_at text default CURRENT_TIMESTAMP
-);
+	);
 -- noqa: enable=PRS
 
 CREATE TABLE plaintiff(
   case_number text not null,
-  plaintiff text,
+  plaintiff text not null,
   FOREIGN KEY(case_number) REFERENCES court_case(case_number)
 );
 
 CREATE TABLE defendant(
   case_number text not null,
-  defendant text,
+  defendant text not null,
   FOREIGN KEY(case_number) REFERENCES court_case(case_number)
 );
 
 CREATE TABLE attorney(
   case_number text not null,
-  attorney text,
+  attorney text not null,
   FOREIGN KEY(case_number) REFERENCES court_case(case_number)
 );
 
 CREATE TABLE event(
   case_number text not null,
-  date text,
+  date text not null CHECK(date IS strftime('%Y-%m-%d', date)),
   description text,
   comments text,
   FOREIGN KEY(case_number) REFERENCES court_case(case_number)

--- a/scripts/initialize_db.sql
+++ b/scripts/initialize_db.sql
@@ -34,7 +34,7 @@ CREATE TABLE attorney(
 
 CREATE TABLE event(
   case_number text not null,
-  date text not null CHECK(date IS strftime('%Y-%m-%d', date)),
+  date text not null,
   description text,
   comments text,
   FOREIGN KEY(case_number) REFERENCES court_case(case_number)

--- a/scripts/initialize_db.sql
+++ b/scripts/initialize_db.sql
@@ -8,7 +8,7 @@ CREATE TABLE court_case(
   calendar text not null,
   ad_damnum text not null,
   court text not null,
-  hash text not null,
+  hash text,
   scraped_at text default CURRENT_TIMESTAMP,
   updated_at text default CURRENT_TIMESTAMP
 	);

--- a/scripts/new_attorneys.sql
+++ b/scripts/new_attorneys.sql
@@ -1,6 +1,6 @@
 CREATE TEMPORARY TABLE raw_attorney (
-    attorney text,
-    case_number text
+    attorney text NOT NULL,
+    case_number text NOT NULL
 );
 
 -- noqa: disable=PRS

--- a/scripts/new_cases.sql
+++ b/scripts/new_cases.sql
@@ -1,12 +1,12 @@
 CREATE TEMPORARY TABLE raw_case (
-    ad_damnum text,
-    calendar text,
-    case_number text,
-    case_type text,
-    court text,
-    division text,
-    filing_date text,
-    hash text,
+    ad_damnum text NOT NULL,
+    calendar text NOT NULL,
+    case_number text NOT NULL,
+    case_type text NOT NULL,
+    court text NOT NULL,
+    division text NOT NULL,
+    filing_date text NOT NULL,
+    hash text NOT NULL,
     scraped_at text DEFAULT current_timestamp,
     updated_at text DEFAULT current_timestamp
 );

--- a/scripts/new_defendants.sql
+++ b/scripts/new_defendants.sql
@@ -1,6 +1,6 @@
 CREATE TEMPORARY TABLE raw_defendant (
-    defendant text,
-    case_number text
+    defendant text NOT NULL,
+    case_number text NOT NULL
 );
 
 -- noqa: disable=PRS

--- a/scripts/new_events.sql
+++ b/scripts/new_events.sql
@@ -1,8 +1,8 @@
 CREATE TEMPORARY TABLE raw_events (
     description text,
-    date text,
+    date text NOT NULL,
     comments text,
-    case_number text
+    case_number text NOT NULL
 );
 
 -- noqa: disable=PRS

--- a/scripts/new_plaintiffs.sql
+++ b/scripts/new_plaintiffs.sql
@@ -1,6 +1,6 @@
 CREATE TEMPORARY TABLE raw_plaintiff (
-    plaintiff text,
-    case_number text
+    plaintiff text NOT NULL,
+    case_number text NOT NULL
 );
 
 -- noqa: disable=PRS


### PR DESCRIPTION
## Overview

This PR adds constraints to most columns in both the script to initialize the database and during the import process for new cases. Though I did update `scripts/initialize_db.sql`, we'll have to manually add the constraints to the deployed database.

Connects #44 

## Notes

Ideally, `court_case.hash` should not be null (and be unique) for any row but since there are already some cases without a hash, I held off on adding that constraint for now. But all new cases should have hashes.
