### PR TITLE
Optimize court call scrape

### DIFF
--- a/.github/workflows/court_calls.yml
+++ b/.github/workflows/court_calls.yml
@@ -2,7 +2,6 @@ name: Court call scrape
 
 on:
   workflow_dispatch:
-  pull_request:
   schedule:
      - cron: '15 10 * * *'
 

--- a/.github/workflows/court_calls.yml
+++ b/.github/workflows/court_calls.yml
@@ -2,6 +2,7 @@ name: Court call scrape
 
 on:
   workflow_dispatch:
+  pull_request:
   schedule:
      - cron: '15 10 * * *'
 

--- a/courtscraper/spiders/court_calls.py
+++ b/courtscraper/spiders/court_calls.py
@@ -1,5 +1,7 @@
 import logging
 from datetime import datetime, timedelta
+from collections import defaultdict
+from itertools import chain
 
 from scrapy import Spider, Request
 from scrapy.http import FormRequest
@@ -14,6 +16,10 @@ from scripts.hash import dict_hash
 class CourtCallSpider(Spider):
     name = "courtcalls"
     url = "https://casesearch.cookcountyclerkofcourt.org/CourtCallSearch.aspx"
+
+    custom_settings = {
+        "CONCURRENT_REQUESTS": 4,
+    }
 
     def __init__(self, **kwargs):
         self.failures = set()
@@ -37,7 +43,8 @@ class CourtCallSpider(Spider):
             count += 1
 
     def start_requests(self):
-        for division in ["CV", "CH"]:
+        # for division in ["CV", "CH"]:
+        for division in ["CV"]:
             for date in self.next_business_days(5):
                 yield Request(
                     CourtCallSpider.url,
@@ -67,7 +74,7 @@ class CourtCallSpider(Spider):
                                     "action": "waitForSelector",
                                     "selector": {
                                         "type": "css",
-                                        "value": "#MainContent_dtTxt",
+                                        "value": "#MainContent_ddlDivisionCode",
                                     },
                                     "timeout": 5,
                                     "onError": "return",
@@ -112,6 +119,7 @@ class CourtCallSpider(Spider):
                         "date": date,
                         "result_page_num": 1,
                         "division": division,
+                        "calendars": {},
                     },
                     errback=self.handle_error,
                     callback=self.parse_results_page,
@@ -136,7 +144,7 @@ class CourtCallSpider(Spider):
             " criteria.')]]"
         )
         if no_results:
-            return None
+            return False
 
         return True
 
@@ -147,31 +155,80 @@ class CourtCallSpider(Spider):
         results_table = tree.xpath("//table[@id='MainContent_grdRecords']")[0]
         rows = results_table.xpath(".//tr")
         headers = rows[0].xpath(".//a/text()")
+
+        court_calls = defaultdict(list)
+        case_details_to_fetch = []
         for result_num, row in enumerate(rows[1:-1]):
             cells = row.xpath(".//td/text()")
             if cells:
                 court_call = dict(zip(headers, cells))
+                case_num = court_call["Case Number"]
 
-                # Get calendar value from the case detail page
-                form_data = self.extract_form(response, "//form[@id='ctl01']")
-                form_data["__EVENTTARGET"] = "ctl00$MainContent$grdRecords"
-                form_data["__EVENTARGUMENT"] = f"Select${result_num}"
-                yield FormRequest.from_response(
-                    response,
-                    meta={"court_call": court_call},
-                    formxpath="//form[@id='ctl01']",
-                    formdata=form_data,
-                    callback=self.parse_calendar,
-                    dont_click=True,
-                )
+                if not court_calls[case_num]:
+                    # We need to remember what position this case occupies
+                    # in the results list to request the detail page
+                    case_details_to_fetch.append((case_num, result_num))
+
+                court_calls[case_num].append(court_call)
+
+        # Start filling in calendar values
+        case_num, result_num = case_details_to_fetch.pop()
+        form_data = self.extract_form(response, "//form[@id='ctl01']")
+        form_data["__EVENTTARGET"] = "ctl00$MainContent$grdRecords"
+        form_data["__EVENTARGUMENT"] = f"Select${result_num}"
+        yield FormRequest.from_response(
+            response,
+            meta={
+                "current_case": case_num,
+                "case_details_to_fetch": case_details_to_fetch,
+                "court_calls": court_calls,
+                "result_page_form": form_data,
+                "result_page_response": response,
+            },
+            formxpath="//form[@id='ctl01']",
+            formdata=form_data,
+            callback=self.parse_calendar,
+            dont_click=True,
+        )
 
     def parse_calendar(self, response):
         """Adds the calendar and hash to a court call's dictionary."""
 
         calendar = response.xpath("//span[@id='MainContent_lblCalendar']/text()").get()
-        court_call = {**response.meta["court_call"], "Calendar": calendar}
-        court_call["hash"] = dict_hash(court_call)
-        return court_call
+        current_case_calls = response.meta["court_calls"][response.meta["current_case"]]
+        for call in current_case_calls:
+            call["Calendar"] = calendar
+            call["hash"] = dict_hash(call)
+
+        if not response.meta["case_details_to_fetch"]:
+            yield from chain.from_iterable(response.meta["court_calls"].values())
+
+        else:
+            # Request the case detail for the next case in our stack
+            next_case_num, next_result_num = response.meta[
+                "case_details_to_fetch"
+            ].pop()
+
+            form_data = response.meta["result_page_form"]
+            form_data["__EVENTARGUMENT"] = f"Select${next_result_num}"
+            yield FormRequest.from_response(
+                response.meta["result_page_response"],
+                meta={
+                    "current_case": next_case_num,
+                    "case_details_to_fetch": response.meta["case_details_to_fetch"],
+                    "court_calls": response.meta["court_calls"],
+                    "result_page_form": form_data,
+                    "result_page_response": response.meta["result_page_response"],
+                },
+                formxpath="//form[@id='ctl01']",
+                formdata=form_data,
+                callback=self.parse_calendar,
+                dont_click=True,
+            )
+
+            logging.info(
+                f"Fetching calendar for case {response.meta['current_case']}..."
+            )
 
     def extract_form(self, response, form_xpath):
         """
@@ -210,6 +267,7 @@ class CourtCallSpider(Spider):
         return form_data
 
     def parse_results_page(self, response):
+        # breakpoint()
         if self.has_results(response):
             yield from self.get_court_calls(response)
         else:
@@ -232,6 +290,13 @@ class CourtCallSpider(Spider):
             key: response.meta[key] for key in ["date", "result_page_num", "division"]
         }
 
+        if next_page_num > 5:
+            return
+
+        logging.info(
+            f"Requesting page {next_page_num} of cases from "
+            f"{response.meta['division']} on {response.meta['date']}..."
+        )
         yield FormRequest.from_response(
             response,
             meta=prev_meta | {"result_page_num": next_page_num},


### PR DESCRIPTION
## Overview

This PR optimizes the court call scrape by:
1. reducing unnecessary requests for associated case calendar values
2. using scrapy's priority queue to avoid "out of order" requests (e.g. we'll complete all the requests for the cases on page 1 of results before moving on to page 2)

Both of these improvements make court call scrapes faster and reduces rejected requests.

Connects #52 