### PR TITLE
Add runtime check to nightly scrape

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,6 @@ name: Nightly case scrape
 
 on:
   workflow_dispatch:
-  pull_request:
   schedule:
      - cron: '15 4 * * *'
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,6 +2,7 @@ name: Nightly case scrape
 
 on:
   workflow_dispatch:
+  pull_request:
   schedule:
      - cron: '15 4 * * *'
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 year=$(shell date +%Y)
+START_TIME=$(shell export TZ=UTC; date -Iseconds)
+TIME_LIMIT=21600
 
 .PHONY: all
 all: upload
@@ -54,11 +56,12 @@ CIVIL_SCRAPE_START_QUERY=$(shell tail -n +2 scripts/nightly_civil_start.sql)
 civil-%.jl: cases.db
 	START=$$(sqlite-utils query --csv --no-headers cases.db \
 	      "$(CIVIL_SCRAPE_START_QUERY)" -p subdivision $*); \
-				echo $$START; \
+	      export START_TIME=$(START_TIME); export TIME_LIMIT=$(TIME_LIMIT); \
 	      scrapy crawl civil -s CLOSESPIDER_TIMEOUT=3600 -a year=$(year) -a division=$* -a start=$$START -O $@;
 
 chancery.jl: cases.db
 	START=$$(sqlite3 cases.db < scripts/nightly_chancery_start.sql); \
+	      export START_TIME=$(START_TIME); export TIME_LIMIT=$(TIME_LIMIT); \
 	      scrapy crawl chancery -a year=$(year) -a start=$$START -O $@;
 
 cases.db :

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 year=$(shell date +%Y)
-START_TIME="2024-05-10T09:09:58.127089+00:00"
+START_TIME=$(shell export TZ=UTC; date -Iseconds)
 TIME_LIMIT=21600
 
 .PHONY: all

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 year=$(shell date +%Y)
-START_TIME=$(shell export TZ=UTC; date -Iseconds)
+START_TIME="2024-05-10T09:09:58.127089+00:00"
 TIME_LIMIT=21600
 
 .PHONY: all

--- a/courtscraper/spiders/chancery.py
+++ b/courtscraper/spiders/chancery.py
@@ -21,6 +21,9 @@ class ChancerySpider(CourtSpiderBase):
 
     def start_requests(self):
         for case_number in self.case_numbers:
+            if self.out_of_time():
+                break
+
             yield Request(
                 ChancerySpider.url,
                 meta={

--- a/courtscraper/spiders/civil.py
+++ b/courtscraper/spiders/civil.py
@@ -13,6 +13,9 @@ class CivilSpider(CourtSpiderBase):
 
     def start_requests(self):
         for case_number in self.case_numbers:
+            if self.out_of_time():
+                break
+
             yield Request(
                 CivilSpider.url,
                 meta={


### PR DESCRIPTION
It looks like the nightly case scrape is still running up against the 6 hour github actions time limit (perhaps because of case backfilling?).

This PR adds logic to keep track of scrape runtime. The nightly scrape should stop if we've been scraping for 5.5 hours (we'll leave 30 minutes for cleanup and deployment). 

Part of #59 