### PR TITLE
Fix start time variable assignment in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-year=$(shell date +%Y)
-START_TIME=$(shell export TZ=UTC; date -Iseconds)
+year:=$(shell date +%Y)
+START_TIME:=$(shell export TZ=UTC; date -Iseconds)
 TIME_LIMIT=21600
 
 .PHONY: all

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 year=$(shell date +%Y)
 START_TIME=$(shell export TZ=UTC; date -Iseconds)
-TIME_LIMIT=3600
+TIME_LIMIT=21600
 
 .PHONY: all
 all: upload

--- a/courtscraper/spiders/chancery.py
+++ b/courtscraper/spiders/chancery.py
@@ -1,4 +1,5 @@
 from scrapy import Request
+from scrapy.exceptions import CloseSpider
 
 from .base import CourtSpiderBase
 
@@ -22,7 +23,8 @@ class ChancerySpider(CourtSpiderBase):
     def start_requests(self):
         for case_number in self.case_numbers:
             if self.out_of_time():
-                break
+                raise CloseSpider("Hit scraping time limit.")
+                return
 
             yield Request(
                 ChancerySpider.url,

--- a/courtscraper/spiders/civil.py
+++ b/courtscraper/spiders/civil.py
@@ -1,4 +1,5 @@
 from scrapy import Request
+from scrapy.exceptions import CloseSpider
 
 from .base import CourtSpiderBase
 
@@ -14,7 +15,8 @@ class CivilSpider(CourtSpiderBase):
     def start_requests(self):
         for case_number in self.case_numbers:
             if self.out_of_time():
-                break
+                raise CloseSpider("Hit scraping time limit.")
+                return
 
             yield Request(
                 CivilSpider.url,


### PR DESCRIPTION
This PR fixes a bug in the Makefile that caused the start time to be calculated at the start of every subdivision scrape rather than at the start of the Makefile run. I also opted to use the `CloseSpider` exception to end scrapers that hit the time limit.

Part of #59 